### PR TITLE
0.2.1

### DIFF
--- a/octoprint_bedlevelingwizard/static/js/BedLevelingWizard.js
+++ b/octoprint_bedlevelingwizard/static/js/BedLevelingWizard.js
@@ -84,7 +84,10 @@ $(function() {
 											sticker: false
 										},
 										addclass: 'stack-bottomleft',
-										stack: stack_bottomleft
+										stack: stack_bottomleft,
+										nonblock: {
+											nonblock: true
+										}
 										}
 									);
 					

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_bedlevelingwizard"
 plugin_name = "Bed Leveling Wizard"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.2.0"
+plugin_version = "0.2.1"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
### Fixes
- Made pop-up instructions non-blocking so if your screen is not 16:9 aspect ratio you can still click the buttons if the pop-up is over the sidebar panel. The pop-up will fade away when you hover the mouse over it like below. Resolves #13.

![image](https://user-images.githubusercontent.com/5249455/48676781-7f86bd00-eb39-11e8-9070-3cbd14496198.png)
